### PR TITLE
Update Gradle Wrapper from 9.7.0 to 9.7.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=a9ecb5ac5c2ca40691e6527724d11d0b43b8c0a52825b77c09899f2a72d2d2bf
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-all.zip
+distributionSha256Sum=92c1a136d76b5017732a66d2e0a648ebff00dd3687d8bff0d0047a1bd904fdf2
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-all.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Update Gradle Wrapper from 9.7.0 to 9.7.1.

Read the release notes: https://docs.gradle.org/9.7.1/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `9.7.1`
- Distribution (-all) zip checksum: `92c1a136d76b5017732a66d2e0a648ebff00dd3687d8bff0d0047a1bd904fdf2`
- Wrapper JAR Checksum: `7a9ce74cff467ca1bf60a4fcd9f05185acceda4d0f382434d393e17864262c5d`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>